### PR TITLE
Speicher- und Buffer-Probleme beim Sync beheben, fehlerhafte Dateien überspringen

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Normalize line endings
+* text=auto
+*.php text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.xml text eol=lf
+*.txt text eol=lf

--- a/SyncDropbox/form.json
+++ b/SyncDropbox/form.json
@@ -28,12 +28,12 @@
 		{ "type": "Label", "caption": "", "visible": false },
 		{ "type": "Label", "name": "BackupSize", "caption": "", "visible": false },
 		{ "type": "Label", "name": "LastFinishedSync", "caption": "", "visible": false },
-		{ "type": "Label", "caption": "" },
+		{ "type": "Label", "name": "BufferLimitInfo", "caption": "", "visible": false },
 		{ "type": "ProgressBar", "name": "UploadProgress", "current": 100, "indeterminate": true, "visible": false },
 		{ "type": "Button", "name": "ForceSync", "caption": "Force Sync", "onClick": "echo SDB_Sync($id);", "visible": false }
 	],
 	"status":
 	[
-		{ "code": 201, "icon": "error", "caption": "Synchronization halted: Too many files" }
+		{ "code": 201, "icon": "error", "caption": "Synchronization halted: Buffer limit reached. See details below." }
 	]
 }

--- a/SyncDropbox/locale.json
+++ b/SyncDropbox/locale.json
@@ -32,7 +32,10 @@
             "Token: Not registered yet": "Token: Noch nicht registriert",
             "Upload limit in minutes per file. Default is 5 minutes": "Upload-Limitation in Minuten pro Datei. Standard ist 5 Minuten.",
             "Upload Limit": "Upload-Limitation",
-            "Synchronization halted: Too many files": "Synchronization pausiert: Zu viele Dateien"
+            "Synchronization halted: Too many files": "Synchronization pausiert: Zu viele Dateien",
+            "Synchronization halted: Buffer limit reached. See details below.": "Synchronisierung angehalten: Buffer-Limit erreicht. Details siehe unten.",
+            "Buffer limit reached (%s): %s; %s": "Buffer-Limit erreicht (%s): %s; %s",
+            "%s: %d bytes (%s)": "%s: %d Bytes (%s)"
         }
     }
 }

--- a/SyncDropbox/module.php
+++ b/SyncDropbox/module.php
@@ -279,7 +279,6 @@ declare(strict_types=1);
 
         private function SaveSyncState(array $fileCache, array $fileQueue, string $context): bool
         {
-            ini_set('memory_limit', '-1');
             $compressedFileCache = gzencode(json_encode($fileCache, JSON_THROW_ON_ERROR));
             $fileCacheSize = strlen($compressedFileCache);
             $this->SendDebug($context, sprintf('We have %d files in your Dropbox (FileCache: %s)', count($fileCache), $this->formatBytes($fileCacheSize)), 0);
@@ -605,6 +604,7 @@ declare(strict_types=1);
 
         public function Sync()
         {
+            ini_set('memory_limit', '-1');
             $this->SetStatus(IS_ACTIVE);
 
             $this->SetTimerInterval('Sync', 0);
@@ -693,6 +693,7 @@ declare(strict_types=1);
 
         public function ReSync()
         {
+            ini_set('memory_limit', '-1');
             if (!$this->ReadPropertyBoolean('Active')) {
                 return;
             }
@@ -751,6 +752,7 @@ declare(strict_types=1);
 
         public function Upload()
         {
+            ini_set('memory_limit', '-1');
             $this->SetTimerInterval('Upload', 0);
 
             if (!$this->ReadPropertyBoolean('Active')) {

--- a/SyncDropbox/module.php
+++ b/SyncDropbox/module.php
@@ -777,15 +777,19 @@ declare(strict_types=1);
             if (count($fileQueue['add']) > 0) {
                 //Upload to Dropbox
                 $this->SendDebug('Upload', sprintf('Adding file... %s. Size %s', $fileQueue['add'][0], $this->formatBytes(filesize($baseDir . $fileQueue['add'][0]))), 0);
-                $dropbox->files->upload('/' . $this->GetDestinationFolder() . '/' . $fileQueue['add'][0], $baseDir . $fileQueue['add'][0]);
+                try {
+                    $dropbox->files->upload('/' . $this->GetDestinationFolder() . '/' . $fileQueue['add'][0], $baseDir . $fileQueue['add'][0]);
 
-                //Add uploaded file to fileCache
-                $fileCache[$this->StrToLower('/' . $this->GetDestinationFolder() . '/' . $fileQueue['add'][0])] = filemtime($baseDir . $fileQueue['add'][0]);
+                    //Add uploaded file to fileCache
+                    $fileCache[$this->StrToLower('/' . $this->GetDestinationFolder() . '/' . $fileQueue['add'][0])] = filemtime($baseDir . $fileQueue['add'][0]);
 
-                //Add to upload statistic
-                $this->SetValue('TransferredMegabytes', $this->GetValue('TransferredMegabytes') + (filesize($baseDir . $fileQueue['add'][0]) / 1024 / 1024));
+                    //Add to upload statistic
+                    $this->SetValue('TransferredMegabytes', $this->GetValue('TransferredMegabytes') + (filesize($baseDir . $fileQueue['add'][0]) / 1024 / 1024));
+                } catch (\Exception $e) {
+                    IPS_LogMessage('SyncDropbox', sprintf('Skipping file (add) due to upload error: %s (%s)', $fileQueue['add'][0], $e->getMessage()));
+                }
 
-                //Remove successful upload
+                //Remove from queue (successful or skipped)
                 array_shift($fileQueue['add']);
 
                 //Start timer for next upload
@@ -793,15 +797,19 @@ declare(strict_types=1);
             } elseif (count($fileQueue['update']) > 0) {
                 //Upload to Dropbox
                 $this->SendDebug('Upload', sprintf('Updating file... %s. Size %s', $fileQueue['update'][0], $this->formatBytes(filesize($baseDir . $fileQueue['update'][0]))), 0);
-                $dropbox->files->upload('/' . $this->GetDestinationFolder() . '/' . $fileQueue['update'][0], $baseDir . $fileQueue['update'][0], 'overwrite');
+                try {
+                    $dropbox->files->upload('/' . $this->GetDestinationFolder() . '/' . $fileQueue['update'][0], $baseDir . $fileQueue['update'][0], 'overwrite');
 
-                //Update uploaded file in fileCache
-                $fileCache[$this->StrToLower('/' . $this->GetDestinationFolder() . '/' . $fileQueue['update'][0])] = filemtime($baseDir . $fileQueue['update'][0]);
+                    //Update uploaded file in fileCache
+                    $fileCache[$this->StrToLower('/' . $this->GetDestinationFolder() . '/' . $fileQueue['update'][0])] = filemtime($baseDir . $fileQueue['update'][0]);
 
-                //Add to upload statistic
-                $this->SetValue('TransferredMegabytes', $this->GetValue('TransferredMegabytes') + (filesize($baseDir . $fileQueue['update'][0]) / 1024 / 1024));
+                    //Add to upload statistic
+                    $this->SetValue('TransferredMegabytes', $this->GetValue('TransferredMegabytes') + (filesize($baseDir . $fileQueue['update'][0]) / 1024 / 1024));
+                } catch (\Exception $e) {
+                    IPS_LogMessage('SyncDropbox', sprintf('Skipping file (update) due to upload error: %s (%s)', $fileQueue['update'][0], $e->getMessage()));
+                }
 
-                //Remove successful upload
+                //Remove from queue (successful or skipped)
                 array_shift($fileQueue['update']);
 
                 $this->SetTimerInterval('Upload', 1000);

--- a/SyncDropbox/module.php
+++ b/SyncDropbox/module.php
@@ -120,7 +120,7 @@ declare(strict_types=1);
             return 'https://' . $this->oauthServer . '/authorize/' . $this->oauthIdentifer . '?username=' . urlencode(IPS_GetLicensee());
         }
 
-        private function FetchRefreshToken($code)
+        private function FetchRefreshToken($code): string
         {
             $this->SendDebug('FetchRefreshToken', 'Use Authentication Code to get our precious Refresh Token!', 0);
 

--- a/SyncDropbox/module.php
+++ b/SyncDropbox/module.php
@@ -6,6 +6,9 @@ declare(strict_types=1);
 
     class SyncDropbox extends IPSModule
     {
+//        private const MAX_BUFFER_SIZE = 256 * 1024;
+        private const MAX_BUFFER_SIZE = 512 * 1024;
+
         //This one needs to be available on our OAuth client backend.
         //Please contact us to register for an identifier: https://www.symcon.de/kontakt/#OAuth
         private $oauthIdentifer = 'sync_dropbox';
@@ -251,6 +254,59 @@ declare(strict_types=1);
             }
         }
 
+        private function formatBufferSizeDetails(string $name, int $size): string
+        {
+            return sprintf($this->Translate('%s: %d bytes (%s)'), $name, $size, $this->formatBytes($size));
+        }
+
+        private function buildBufferLimitMessage(int $fileCacheSize, int $fileQueueSize): string
+        {
+            $offenders = [];
+            if ($fileCacheSize >= self::MAX_BUFFER_SIZE) {
+                $offenders[] = 'FileCache';
+            }
+            if ($fileQueueSize >= self::MAX_BUFFER_SIZE) {
+                $offenders[] = 'FileQueue';
+            }
+
+            return sprintf(
+                $this->Translate('Buffer limit reached (%s): %s; %s'),
+                implode(', ', $offenders),
+                $this->formatBufferSizeDetails('FileCache', $fileCacheSize),
+                $this->formatBufferSizeDetails('FileQueue', $fileQueueSize)
+            );
+        }
+
+        private function SaveSyncState(array $fileCache, array $fileQueue, string $context): bool
+        {
+            $compressedFileCache = gzencode(json_encode($fileCache, JSON_THROW_ON_ERROR));
+            $fileCacheSize = strlen($compressedFileCache);
+            $this->SendDebug($context, sprintf('We have %d files in your Dropbox (FileCache: %s)', count($fileCache), $this->formatBytes($fileCacheSize)), 0);
+
+            $compressedFileQueue = gzencode(json_encode($fileQueue, JSON_THROW_ON_ERROR));
+            $fileQueueSize = strlen($compressedFileQueue);
+            $this->SendDebug($context, sprintf('Queue = Add: %d, Update: %d, Remove: %d (FileQueue: %s)', count($fileQueue['add']), count($fileQueue['update']), count($fileQueue['delete']), $this->formatBytes($fileQueueSize)), 0);
+
+            if (($fileCacheSize >= self::MAX_BUFFER_SIZE) || ($fileQueueSize >= self::MAX_BUFFER_SIZE)) {
+                $message = $this->buildBufferLimitMessage($fileCacheSize, $fileQueueSize);
+                $this->SendDebug($context, $message, 0);
+                $this->SetBuffer('LimitError', $message);
+                $this->SetStatus(IS_EBASE + 1);
+                $this->SetTimerInterval('Upload', 0);
+                $this->UpdateFormField('UploadProgress', 'visible', false);
+                $this->UpdateFormField('BufferLimitInfo', 'caption', $message);
+                $this->UpdateFormField('BufferLimitInfo', 'visible', true);
+                $this->UpdateFormField('ForceSync', 'visible', true);
+                return false;
+            }
+
+            $this->SetBuffer('LimitError', '');
+            $this->UpdateFormField('BufferLimitInfo', 'visible', false);
+            $this->SetBuffer('FileCache', $compressedFileCache);
+            $this->SetBuffer('FileQueue', $compressedFileQueue);
+            return true;
+        }
+
         //Source: https://github.com/dropbox/dropbox-api-content-hasher/pull/2
         private function dropbox_hash_stream($stream, $chunksize = 8 * 1024)
         {
@@ -354,6 +410,11 @@ declare(strict_types=1);
                         $data->actions[6]->caption = $this->Translate('Last Synchronization') . ': ' . date('d.m.Y H:i', intval($this->GetBuffer('LastFinishedSync')));
                     } else {
                         $data->actions[6]->caption = $this->Translate('Last Synchronization') . ': ' . $this->Translate('Never');
+                    }
+
+                    if ($this->GetBuffer('LimitError') != '') {
+                        $data->actions[7]->visible = true;
+                        $data->actions[7]->caption = $this->GetBuffer('LimitError');
                     }
 
                     if ($this->GetBuffer('FileQueue') != '') {
@@ -607,25 +668,9 @@ declare(strict_types=1);
             $fileQueue = $this->CalculateFileQueue($fileCache);
 
             //Save all entries for partial sync
-            $compressedFileCache = gzencode(json_encode($fileCache, JSON_THROW_ON_ERROR));
-            $this->SendDebug('Sync', sprintf('We have %d files in your Dropbox (FileCache: %s)', count($fileCache), $this->formatBytes(strlen($compressedFileCache))), 0);
-
-            //Save the FileQueue which the Upload function will process
-            $compressedFileQueue = gzencode(json_encode($fileQueue, JSON_THROW_ON_ERROR));
-            $this->SendDebug('Sync', sprintf('Sync = Add: %d, Update: %d, Remove: %d (FileQueue: %s)', count($fileQueue['add']), count($fileQueue['update']), count($fileQueue['delete']), $this->formatBytes(strlen($compressedFileQueue))), 0);
-
-            //Show error if we have too many files
-            if ((strlen($compressedFileCache) >= 512 * 1024) || (strlen($compressedFileQueue) >= 512 * 1024)) {
-                $this->SetStatus(IS_EBASE + 1);
-
-                $this->UpdateFormField('UploadProgress', 'visible', false);
-                $this->UpdateFormField('ForceSync', 'visible', true);
-
+            if (!$this->SaveSyncState($fileCache, $fileQueue, 'Sync')) {
                 return;
             }
-
-            $this->SetBuffer('FileCache', $compressedFileCache);
-            $this->SetBuffer('FileQueue', $compressedFileQueue);
 
             //Start Upload if there is anything to do
             if (count($fileQueue['add']) > 0 || count($fileQueue['update']) > 0 || count($fileQueue['delete']) > 0) {
@@ -684,15 +729,9 @@ declare(strict_types=1);
             //Build the add/update/delete queue. Will also update the fileCache!
             $fileQueue = $this->CalculateFileQueue($fileCache);
 
-            //Save the updated FileCache
-            $compressedFileCache = gzencode(json_encode($fileCache, JSON_THROW_ON_ERROR));
-            $this->SendDebug('ReSync', sprintf('We have %d files in your Dropbox (FileCache: %s)', count($fileCache), $this->formatBytes(strlen($compressedFileCache))), 0);
-            $this->SetBuffer('FileCache', $compressedFileCache);
-
-            //Save the updated FileQueue
-            $compressedFileQueue = gzencode(json_encode($fileQueue, JSON_THROW_ON_ERROR));
-            $this->SendDebug('ReSync', sprintf('ReSync = Add: %d, Update: %d, Remove: %d (FileQueue: %s)', count($fileQueue['add']), count($fileQueue['update']), count($fileQueue['delete']), $this->formatBytes(strlen($compressedFileQueue))), 0);
-            $this->SetBuffer('FileQueue', $compressedFileQueue);
+            if (!$this->SaveSyncState($fileCache, $fileQueue, 'ReSync')) {
+                return;
+            }
 
             //Start Upload if there is anything to do
             if (count($fileQueue['add']) > 0 || count($fileQueue['update']) > 0 || count($fileQueue['delete']) > 0) {
@@ -795,11 +834,9 @@ declare(strict_types=1);
                 $this->UpdateFormField('ForceSync', 'visible', true);
             }
 
-            //Save the updated FileCache
-            $this->SetBuffer('FileCache', gzencode(json_encode($fileCache, JSON_THROW_ON_ERROR)));
-
-            //Save the updated FileQueue
-            $this->SetBuffer('FileQueue', gzencode(json_encode($fileQueue, JSON_THROW_ON_ERROR)));
+            if (!$this->SaveSyncState($fileCache, $fileQueue, 'Upload')) {
+                return;
+            }
 
             //Save timestamp of last action
             $this->SetBuffer('LastUpload', time());

--- a/SyncDropbox/module.php
+++ b/SyncDropbox/module.php
@@ -279,6 +279,7 @@ declare(strict_types=1);
 
         private function SaveSyncState(array $fileCache, array $fileQueue, string $context): bool
         {
+            ini_set('memory_limit', '-1');
             $compressedFileCache = gzencode(json_encode($fileCache, JSON_THROW_ON_ERROR));
             $fileCacheSize = strlen($compressedFileCache);
             $this->SendDebug($context, sprintf('We have %d files in your Dropbox (FileCache: %s)', count($fileCache), $this->formatBytes($fileCacheSize)), 0);

--- a/library.json
+++ b/library.json
@@ -7,6 +7,6 @@
 		"version": "6.0"
 	},
 	"version": "1.8",
-	"build": 0,
+	"build": 1,
 	"date": 1781820000
 }

--- a/library.json
+++ b/library.json
@@ -6,7 +6,7 @@
 	"compatibility": {
 		"version": "6.0"
 	},
-	"version": "1.7",
+	"version": "1.8",
 	"build": 0,
-	"date": 0
+	"date": 1781820000
 }

--- a/library.json
+++ b/library.json
@@ -7,6 +7,6 @@
 		"version": "6.0"
 	},
 	"version": "1.8",
-	"build": 1,
-	"date": 1781820000
+	"build": 2,
+	"date": 1781992800
 }

--- a/libs/Dropbox.php
+++ b/libs/Dropbox.php
@@ -123,7 +123,7 @@ namespace Dropbox;
             $endpoint = 'https://content.dropboxapi.com/2/files/upload';
             $headers = [
                 'Content-Type: application/octet-stream',
-                "Dropbox-API-Arg: {\"path\": \"$target_path\", \"mode\": \"$mode\"}"
+                'Dropbox-API-Arg: ' . json_encode(['path' => $target_path, 'mode' => $mode])
             ];
             if (file_exists($file_data)) {
                 $postdata = file_get_contents($file_data);


### PR DESCRIPTION
## Überblick

Behebt mehrere Probleme, die bei Anwendern mit größeren Backups zu Fatal Errors und Abbrüchen während der Synchronisierung führten.

## Änderungen

- **Memory-Limit**: `memory_limit` wird zu Beginn von Sync, ReSync und Upload auf unbegrenzt gesetzt, um `Allowed memory size exhausted` Fatal Errors zu vermeiden.
- **Buffer-Limit-Details**: Bei Erreichen des Buffer-Limits wird nun angezeigt, welcher Buffer (FileCache/FileQueue) betroffen ist, inkl. Größenangaben. Logik in `SaveSyncState()` zusammengefasst (verwendet von Sync, ReSync und Upload).
- **Sonderzeichen in Pfaden**: Der `Dropbox-API-Arg`-Header wird jetzt korrekt per `json_encode()` erzeugt statt per String-Interpolation. Behebt `could not decode input as JSON`.
- **Fehlerhafte Dateien überspringen**: Dateien mit von Dropbox abgelehntem Pfad (z. B. `malformed_path`) brechen den Upload nicht mehr ab, sondern werden übersprungen und mit `IPS_LogMessage` ins Symcon-Meldungs-Log geschrieben.
- **Zeilenenden**: `.gitattributes` zur Normalisierung auf LF ergänzt.
- Kleinere Aufräumarbeiten (Return-Type-Hint).

## Versionsstand

library.json: Version 1.8, build 2.